### PR TITLE
added status to posts and comments, only showing public

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,7 +17,7 @@ class CommentsController < ApplicationController
   end 
 
   private def comment_params 
-    params.require(:comment).permit(:username, :body)
+    params.require(:comment).permit(:username, :body, :status)
   end 
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -61,7 +61,7 @@ class PostsController < ApplicationController
   # Strong parameters types the params passed to requests and db.  
   private def post_params 
     # Prevents malicious code submission from forms.  
-    params.require(:post).permit(:title, :body)
+    params.require(:post).permit(:title, :body, :status)
   end 
 
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
+  include Visible
   belongs_to :post
 end

--- a/app/models/concerns/visible.rb
+++ b/app/models/concerns/visible.rb
@@ -1,0 +1,23 @@
+module Visible
+  extend ActiveSupport::Concern
+
+  VALID_STATUSES = ['public', 'private', 'archived']
+
+  included do
+    validates :status, inclusion: { in: VALID_STATUSES }
+  end
+
+  class_methods do
+    def public_count
+      where(status: 'public').count
+    end
+  end
+
+  def archived?
+    status == 'archived'
+  end
+
+  def public? 
+    status == 'public'
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-
+include Visible
 has_many  :comments, dependent: :delete_all
 
 # A string being required includes one non-white space character. 

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,17 +1,19 @@
 
 <h3 class="mt-3">Comments</h3>
 <% @post.comments.each do |comment| %>
-<div class="card bg-light m-2 mb-3">
-<div class="card-body">
-    <p>
-    <strong>
-        <%= comment.username %> 
-      </strong>
-    </p>
-    <p>
-      <%= comment.body %>
-    </p>
-    <%= link_to '[x]', [comment.post, comment], method: :delete %>
+  <% if comment.public? %>
+  <div class="card bg-light m-2 mb-3">
+  <div class="card-body">
+      <p>
+      <strong>
+          <%= comment.username %> 
+        </strong>
+      </p>
+      <p>
+        <%= comment.body %>
+      </p>
+      <%= link_to '[x]', [comment.post, comment], method: :delete %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,16 +1,23 @@
-<h3>
-  Add Comment 
-</h3>
-<%= form_for([@post, @post.comments.build]) do |f| %>
-  <p>
-    <%= f.label :username %>
-    <%= f.text_field(:username, {:class => 'form-control'}) %>
-  </p>
-  <p>
-    <%= f.label :body %>
-    <%= f.text_area(:body, {:class => 'form-control'}) %>
-  </p>
-  <p> 
-    <%= f.submit({:class => 'btn btn-primary'}) %>
-  </p>
-<% end %> 
+<div class="card bg-light">
+  <div class="card-body">
+    <h3 class="card-title">
+      Add Comment 
+    </h3>
+    <%= form_for([@post, @post.comments.build]) do |f| %>
+      <div>
+        <p>
+          <%= f.label :username %>
+          <%= f.text_field(:username, {:class => 'form-control'}) %>
+        </p>
+        <p>
+          <%= f.label :body %>
+          <%= f.text_area(:body, {:class => 'form-control'}) %>
+          <%= f.select(:status, ['public', 'private', 'archived'], {selected: 'public'}, {:class => 'form-select my-3'} ) %>
+        </p>
+        <p> 
+          <%= f.submit({:class => 'btn btn-primary'}) %>
+        </p>
+      </div>
+    <% end %> 
+  </div>
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,6 +14,7 @@
 <p>
   <%= f.label :body %>
   <%= f.text_area(:body, {:class => 'form-control'}) %>
+  <%= f.select(:status, ['public', 'private', 'archived'], {selected: 'public'}, {:class => 'form-select my-3'} ) %>
 </p>
 <span>
   <%= f.submit({:class => 'btn btn-primary'})%>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,16 +1,19 @@
 <div class="mt-4">
   <h1>Blog posts</h1>
+  <p class='mx-1'>Currently browsing <%= Post.public_count %> public posts.</p>
     <% @post.each do |post| %>
-    <div class="card bg-light my-3">
-      <div class="card-body">
-        <h3>
-            <%= post.title %>
-        </h3>
-        <p>
-            <%= post.body %>
-        </p>
-        <%= link_to "Read More!", post_path(post), :class => 'btn btn-secondary'%>
+    <% if post.public? %>
+      <div class="card bg-light my-3">
+        <div class="card-body">
+          <h3>
+              <%= post.title %>
+          </h3>
+          <p>
+              <%= post.body %>
+          </p>
+          <%= link_to "Read More!", post_path(post), :class => 'btn btn-secondary'%>
+        </div>
       </div>
-    </div>
+    <% end %>
     <% end %>
 </div>

--- a/db/migrate/20211006042945_add_status_to_posts.rb
+++ b/db/migrate/20211006042945_add_status_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStatusToPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :status, :string, default: 'public'
+  end
+end

--- a/db/migrate/20211006043726_add_status_to_comments.rb
+++ b/db/migrate/20211006043726_add_status_to_comments.rb
@@ -1,0 +1,5 @@
+class AddStatusToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :comments, :status, :string, default: 'public'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_055004) do
+ActiveRecord::Schema.define(version: 2021_10_06_043726) do
 
   create_table "comments", force: :cascade do |t|
     t.string "username"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_055004) do
     t.integer "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "public"
     t.index ["post_id"], name: "index_comments_on_post_id"
   end
 
@@ -26,6 +27,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_055004) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "public"
   end
 
 end


### PR DESCRIPTION
Creates two migrations to add status to Post and Comment models with default value 'public'.  
Adds a new Concern called Visible and adds this to both Post and Comment. 
Create forms changed to include a form select for new status field. 
Views updated to currently display posts and comments with public status. 

[ Work still to do:
Consider adding visibility for private status Posts and Comments for authenticated users. 
Consider adding functionality to authenticated user to archive Posts and Comments.
After the status fields were added, I started over with a new database. 
If I added a new status field with a default value, how would I go over existing data to add the missing value?
]
